### PR TITLE
[Temporaries] Enable four-parts images

### DIFF
--- a/combirepo/temporaries.py
+++ b/combirepo/temporaries.py
@@ -169,9 +169,9 @@ def mount_firmware(firmware_path):
         image = images[0]
         mount_image(root, image)
     # For 3-parts and 6-parts images:
-    elif len(images) == 3 or len(images) == 6:
+    elif len(images) in [3, 4, 6]:
         __mount_images_triplet(images, root)
     else:
         raise Exception("This script is able to handle only all-in-one or "
-                        "three- or six-parted images!")
+                        "three-, four- or six-parted images!")
     return root


### PR DESCRIPTION
Current san-tizen-5.0-unified-asan snapshots have
additional partition for swap.

Signed-off-by: Anastasia Lyupa <a.lyupa@samsung.com>